### PR TITLE
Fixed landscape image overflow in mobile view

### DIFF
--- a/assets/css/default.sass
+++ b/assets/css/default.sass
@@ -115,7 +115,7 @@ li.timeline-item
       max-height: 30rem
 
     img
-      max-width: 20rem
+      max-width: 100%
       max-height: 20rem
 
 li.year-item


### PR DESCRIPTION
In mobile view landscape images caused an overflow of the main content box. This limits the width of the image to the content box.