### PR TITLE
/ueber: füge notwendige Bindestriche hinzu

### DIFF
--- a/ueber.md
+++ b/ueber.md
@@ -3,8 +3,8 @@ title: Über dieses Projekt
 ---
 
 Das Projekt Clankriminalität sammelt und kuratiert Korruptionsfälle und deren Verdachtsfälle
-sowie Fälle von Lobbyismus und Verquickung von Mandat und persönlichen Interessen von CDU und
-CSU PolitikerInnen, der so genannten Union. Die Union schafft es immer wieder, Vergessen zu produzieren.
+sowie Fälle von Lobbyismus und Verquickung von Mandat und persönlichen Interessen von CDU- und
+CSU-PolitikerInnen, der so genannten Union. Die Union schafft es immer wieder, Vergessen zu produzieren.
 Wir sind ein Kollektiv, das diesem Vergessen entgegenwirken will. Deshalb haben wir uns
 zusammengeschlossen, um diese Webseite zu betreiben.
 


### PR DESCRIPTION
«CDU» und «CSU» fungieren im Deutschen als Nomen, nicht als Adjektive. Anders als im Englischen werden im Deutschen zusammengesetzte Nomen zusammen- oder mit Bindestrich geschrieben, nicht mit Leerschlag.